### PR TITLE
Closes #36 Add explicit failure for deprecated input formats

### DIFF
--- a/__snap2/DoublyLinkedList.js
+++ b/__snap2/DoublyLinkedList.js
@@ -1,0 +1,237 @@
+class Node {
+  constructor(element) {
+    this.element = element
+    this.next = null
+    this.prev = null
+  }
+}
+
+class DoubleLinkedList {
+  constructor() {
+    this.length = 0
+    this.head = null
+    this.tail = null
+  }
+
+  // Add new element
+  append(element) {
+    const node = new Node(element)
+
+    if (!this.head) {
+      this.head = node
+      this.tail = node
+    } else {
+      node.prev = this.tail
+      this.tail.next = node
+      this.tail = node
+    }
+
+    this.length++
+  }
+
+  // Add element
+  insert(position, element) {
+    // Check of out-of-bound values
+    if (position >= 0 && position <= this.length) {
+      const node = new Node(element)
+      let current = this.head
+      let previous = 0
+      let index = 0
+
+      if (position === 0) {
+        if (!this.head) {
+          this.head = node
+          this.tail = node
+        } else {
+          node.next = current
+          current.prev = node
+          this.head = node
+        }
+      } else if (position === this.length) {
+        current = this.tail
+        current.next = node
+        node.prev = current
+        this.tail = node
+      } else {
+        while (index++ < position) {
+          previous = current
+          current = current.next
+        }
+
+        node.next = current
+        previous.next = node
+
+        // New
+        current.prev = node
+        node.prev = previous
+      }
+
+      this.length++
+      return true
+    } else {
+      return false
+    }
+  }
+
+  // Remove element at any position
+  removeAt(position) {
+    // look for out-of-bounds value
+    if (position > -1 && position < this.length) {
+      let current = this.head
+      let previous = 0
+      let index = 0
+
+      // Removing first item
+      if (position === 0) {
+        this.head = current.next
+
+        // if there is only one item, update this.tail //NEW
+        if (this.length === 1) {
+          this.tail = null
+        } else {
+          this.head.prev = null
+        }
+      } else if (position === this.length - 1) {
+        current = this.tail
+        this.tail = current.prev
+        this.tail.next = null
+      } else {
+        while (index++ < position) {
+          previous = current
+          current = current.next
+        }
+
+        // link previous with current's next - skip it
+        previous.next = current.next
+        current.next.prev = previous
+      }
+
+      this.length--
+      return current.element
+    } else {
+      return null
+    }
+  }
+
+  // Get the indexOf item
+  indexOf(elm) {
+    let current = this.head
+    let index = -1
+
+    // If element found then return its position
+    while (current) {
+      if (elm === current.element) {
+        return ++index
+      }
+
+      index++
+      current = current.next
+    }
+
+    // Else return -1
+    return -1
+  }
+
+  // Find the item in the list
+  isPresent(elm) {
+    return this.indexOf(elm) !== -1
+  }
+
+  // Delete an item from the list
+  delete(elm) {
+    return this.removeAt(this.indexOf(elm))
+  }
+
+  // Delete first item from the list
+  deleteHead() {
+    this.removeAt(0)
+  }
+
+  // Delete last item from the list
+  deleteTail() {
+    this.removeAt(this.length - 1)
+  }
+
+  // Print item of the string
+  toString() {
+    let current = this.head
+    let string = ''
+
+    while (current) {
+      string += current.element + (current.next ? '\n' : '')
+      current = current.next
+    }
+
+    return string
+  }
+
+  // Convert list to array
+  toArray() {
+    const arr = []
+    let current = this.head
+
+    while (current) {
+      arr.push(current.element)
+      current = current.next
+    }
+
+    return arr
+  }
+
+  // Check if list is empty
+  isEmpty() {
+    return this.length === 0
+  }
+
+  // Get the size of the list
+  size() {
+    return this.length
+  }
+
+  // Get the this.head
+  getHead() {
+    return this.head
+  }
+
+  // Get the this.tail
+  getTail() {
+    return this.tail
+  }
+
+  // Method to iterate over the LinkedList
+  iterator() {
+    let currentNode = this.getHead()
+    if (currentNode === null) return -1
+
+    const iterate = function* () {
+      while (currentNode) {
+        yield currentNode.element
+        currentNode = currentNode.next
+      }
+    }
+    return iterate()
+  }
+
+  // Method to log the LinkedList, for debugging
+  // it' a circular structure, so can't use stringify to debug the whole structure
+  log() {
+    let currentNode = this.getHead()
+    while (currentNode) {
+      console.log(currentNode.element)
+      currentNode = currentNode.next
+    }
+  }
+}
+
+// Example
+
+// const newDoubleLinkedList = new DoubleLinkedList()
+// newDoubleLinkedList.append(1)
+// newDoubleLinkedList.append(2)
+// newDoubleLinkedList.size() // returns 2
+// const iterate = newDoubleLinkedList.iterator()
+// console.log(iterate.next().value) // 1
+// console.log(iterate.next().value) // 2
+// console.log(newDoubleLinkedList.log())
+
+export { DoubleLinkedList }

--- a/__snap2/PiApproximationMonteCarlo.js
+++ b/__snap2/PiApproximationMonteCarlo.js
@@ -1,0 +1,21 @@
+// Wikipedia: https://en.wikipedia.org/wiki/Monte_Carlo_method
+// Video Explanation: https://www.youtube.com/watch?v=ELetCV_wX_c
+
+const piEstimation = (iterations = 100000) => {
+  let circleCounter = 0
+
+  for (let i = 0; i < iterations; i++) {
+    // generating random points and checking if it lies within a circle of radius 1
+    const x = Math.random()
+    const y = Math.random()
+    const radius = Math.sqrt(Math.pow(x, 2) + Math.pow(y, 2))
+
+    if (radius < 1) circleCounter += 1
+  }
+
+  // formula for pi = (ratio of number inside circle and total iteration) x 4
+  const pi = (circleCounter / iterations) * 4
+  return pi
+}
+
+export { piEstimation }

--- a/__snap2/ROT13.test.js
+++ b/__snap2/ROT13.test.js
@@ -1,0 +1,22 @@
+import ROT13 from '../ROT13'
+
+describe('Testing ROT13 function', () => {
+  it('Test - 1, passing a non-string as an argument', () => {
+    expect(() => ROT13(0x345)).toThrow()
+    expect(() => ROT13(123)).toThrow()
+    expect(() => ROT13(123n)).toThrow()
+    expect(() => ROT13(false)).toThrow()
+    expect(() => ROT13({})).toThrow()
+    expect(() => ROT13([])).toThrow()
+  })
+
+  it('Test - 2, passing a string as an argument', () => {
+    expect(ROT13('Uryyb Jbeyq')).toBe('Hello World')
+    expect(ROT13('ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz')).toBe(
+      'NOPQRSTUVWXYZABCDEFGHIJKLMnopqrstuvwxyzabcdefghijklm'
+    )
+    expect(ROT13('The quick brown fox jumps over the lazy dog')).toBe(
+      'Gur dhvpx oebja sbk whzcf bire gur ynml qbt'
+    )
+  })
+})

--- a/__snap2/sha1.cpp
+++ b/__snap2/sha1.cpp
@@ -1,0 +1,307 @@
+/**
+ * @file
+ * @author [tGautot](https://github.com/tGautot)
+ * @brief Simple C++ implementation of the [SHA-1 Hashing
+ * Algorithm](https://en.wikipedia.org/wiki/SHA-1)
+ *
+ * @details
+ * [SHA-1](https://en.wikipedia.org/wiki/SHA-1) is a cryptographic hash function
+ * that was developped by the
+ * [NSA](https://en.wikipedia.org/wiki/National_Security_Agency) 1995.
+ * SHA-1 is not considered secure since around 2010.
+ *
+ * ### Algorithm
+ * The first step of the algorithm is to pad the message for its length to
+ * be a multiple of 64 (bytes). This is done by first adding 0x80 (10000000)
+ * and then only zeroes until the last 8 bytes must be filled, where then the
+ * 64 bit size of the input will be added
+ *
+ * Once this is done, the algo breaks down this padded message
+ * into 64 bytes chunks. Each chunk is used for one *round*, a round
+ * breaks the chunk into 16 blocks of 4 bytes. These 16 blocks are then extended
+ * to 80 blocks using XOR operations on existing blocks (see code for more
+ * details). The algorithm will then update its 160-bit state (here represented
+ * used 5 32-bits integer) using partial hashes computed using special functions
+ * on the blocks previously built. Please take a look at the [wikipedia
+ * article](https://en.wikipedia.org/wiki/SHA-1#SHA-1_pseudocode) for more
+ * precision on these operations
+ * @note This is a simple implementation for a byte string but
+ * some implmenetations can work on bytestream, messages of unknown length.
+ */
+
+#include <algorithm>  /// For std::copy
+#include <array>      /// For std::array
+#include <cassert>    /// For assert
+#include <cstdint>
+#include <cstring>    /// For std::memcopy
+#include <iostream>   /// For IO operations
+#include <string>     /// For strings
+#include <vector>     /// For std::vector
+
+/**
+ * @namespace hashing
+ * @brief Hashing algorithms
+ */
+namespace hashing {
+/**
+ * @namespace SHA-1
+ * @brief Functions for the [SHA-1](https://en.wikipedia.org/wiki/SHA-1)
+ * algorithm implementation
+ */
+namespace sha1 {
+/**
+ * @brief Rotates the bits of a 32-bit unsigned integer
+ * @param n Integer to rotate
+ * @param rotate How many bits for the rotation
+ * @return uint32_t The rotated integer
+ */
+uint32_t leftRotate32bits(uint32_t n, std::size_t rotate) {
+    return (n << rotate) | (n >> (32 - rotate));
+}
+
+/**
+ * @brief Transforms the 160-bit SHA-1 signature into a 40 char hex string
+ * @param sig The SHA-1 signature (Expected 20 bytes)
+ * @return std::string The hex signature
+ */
+std::string sig2hex(void* sig) {
+    const char* hexChars = "0123456789abcdef";
+    auto* intsig = static_cast<uint8_t*>(sig);
+    std::string hex = "";
+    for (uint8_t i = 0; i < 20; i++) {
+        hex.push_back(hexChars[(intsig[i] >> 4) & 0xF]);
+        hex.push_back(hexChars[(intsig[i]) & 0xF]);
+    }
+    return hex;
+}
+
+/**
+ * @brief The SHA-1 algorithm itself, taking in a bytestring
+ * @param input_bs The bytestring to hash
+ * @param input_size The size (in BYTES) of the input
+ * @return void* Pointer to the 160-bit signature
+ */
+void* hash_bs(const void* input_bs, uint64_t input_size) {
+    auto* input = static_cast<const uint8_t*>(input_bs);
+
+    // Step 0: The initial 160-bit state
+    uint32_t h0 = 0x67452301, a = 0;
+    uint32_t h1 = 0xEFCDAB89, b = 0;
+    uint32_t h2 = 0x98BADCFE, c = 0;
+    uint32_t h3 = 0x10325476, d = 0;
+    uint32_t h4 = 0xC3D2E1F0, e = 0;
+
+    // Step 1: Processing the bytestring
+    // First compute the size the padded message will have
+    // so it is possible to allocate the right amount of memory
+    uint64_t padded_message_size = 0;
+    if (input_size % 64 < 56) {
+        padded_message_size = input_size + 64 - (input_size % 64);
+    } else {
+        padded_message_size = input_size + 128 - (input_size % 64);
+    }
+
+    // Allocate the memory for the padded message
+    std::vector<uint8_t> padded_message(padded_message_size);
+
+    // Beginning of the padded message is the original message
+    std::copy(input, input + input_size, padded_message.begin());
+
+    // Afterwards comes a single 1 bit and then only zeroes
+    padded_message[input_size] = 1 << 7;  // 10000000
+    for (uint64_t i = input_size; i % 64 != 56; i++) {
+        if (i == input_size) {
+            continue;  // pass first iteration
+        }
+        padded_message[i] = 0;
+    }
+
+    // We then have to add the 64-bit size of the message in bits (hence the
+    // times 8) in the last 8 bytes
+    uint64_t input_bitsize = input_size * 8;
+    for (uint8_t i = 0; i < 8; i++) {
+        padded_message[padded_message_size - 8 + i] =
+            (input_bitsize >> (56 - 8 * i)) & 0xFF;
+    }
+
+    // Already allocate memory for blocks
+    std::array<uint32_t, 80> blocks{};
+
+    // Rounds
+    for (uint64_t chunk = 0; chunk * 64 < padded_message_size; chunk++) {
+        // First, build 16 32-bits blocks from the chunk
+        for (uint8_t bid = 0; bid < 16; bid++) {
+            blocks[bid] = 0;
+
+            // Having to build a 32-bit word from 4-bit words
+            // Add each and shift them to the left
+            for (uint8_t cid = 0; cid < 4; cid++) {
+                blocks[bid] = (blocks[bid] << 8) +
+                              padded_message[chunk * 64 + bid * 4 + cid];
+            }
+
+            // Extend the 16 32-bit words into 80 32-bit words
+            for (uint8_t i = 16; i < 80; i++) {
+                blocks[i] =
+                    leftRotate32bits(blocks[i - 3] ^ blocks[i - 8] ^
+                                         blocks[i - 14] ^ blocks[i - 16],
+                                     1);
+            }
+        }
+
+        a = h0;
+        b = h1;
+        c = h2;
+        d = h3;
+        e = h4;
+
+        // Main "hashing" loop
+        for (uint8_t i = 0; i < 80; i++) {
+            uint32_t F = 0, g = 0;
+            if (i < 20) {
+                F = (b & c) | ((~b) & d);
+                g = 0x5A827999;
+            } else if (i < 40) {
+                F = b ^ c ^ d;
+                g = 0x6ED9EBA1;
+            } else if (i < 60) {
+                F = (b & c) | (b & d) | (c & d);
+                g = 0x8F1BBCDC;
+            } else {
+                F = b ^ c ^ d;
+                g = 0xCA62C1D6;
+            }
+
+            // Update the accumulators
+            uint32_t temp = leftRotate32bits(a, 5) + F + e + g + blocks[i];
+            e = d;
+            d = c;
+            c = leftRotate32bits(b, 30);
+            b = a;
+            a = temp;
+        }
+        // Update the state with this chunk's hash
+        h0 += a;
+        h1 += b;
+        h2 += c;
+        h3 += d;
+        h4 += e;
+    }
+
+    // Build signature from state
+    // Note, any type could be used for the signature
+    // uint8_t was used to make the 20 bytes obvious
+    auto* sig = new uint8_t[20];
+    for (uint8_t i = 0; i < 4; i++) {
+        sig[i] = (h0 >> (24 - 8 * i)) & 0xFF;
+        sig[i + 4] = (h1 >> (24 - 8 * i)) & 0xFF;
+        sig[i + 8] = (h2 >> (24 - 8 * i)) & 0xFF;
+        sig[i + 12] = (h3 >> (24 - 8 * i)) & 0xFF;
+        sig[i + 16] = (h4 >> (24 - 8 * i)) & 0xFF;
+    }
+
+    return sig;
+}
+
+/**
+ * @brief Converts the string to bytestring and calls the main algorithm
+ * @param message Plain character message to hash
+ * @return void* Pointer to the SHA-1 signature
+ */
+void* hash(const std::string& message) {
+    return hash_bs(&message[0], message.size());
+}
+}  // namespace sha1
+}  // namespace hashing
+
+/**
+ * @brief Self-test implementations of well-known SHA-1 hashes
+ * @returns void
+ */
+static void test() {
+    // Hashes empty string and stores signature
+    void* sig = hashing::sha1::hash("");
+    std::cout << "Hashing empty string" << std::endl;
+    // Prints signature hex representation
+    std::cout << hashing::sha1::sig2hex(sig) << std::endl << std::endl;
+    // Test with cassert wether sig is correct from expected value
+    assert(hashing::sha1::sig2hex(sig).compare(
+               "da39a3ee5e6b4b0d3255bfef95601890afd80709") == 0);
+
+    // Hashes "The quick brown fox jumps over the lazy dog" and stores signature
+    void* sig2 =
+        hashing::sha1::hash("The quick brown fox jumps over the lazy dog");
+    std::cout << "Hashing The quick brown fox jumps over the lazy dog"
+              << std::endl;
+    // Prints signature hex representation
+    std::cout << hashing::sha1::sig2hex(sig2) << std::endl << std::endl;
+    // Test with cassert wether sig is correct from expected value
+    assert(hashing::sha1::sig2hex(sig2).compare(
+               "2fd4e1c67a2d28fced849ee1bb76e7391b93eb12") == 0);
+
+    // Hashes "The quick brown fox jumps over the lazy dog." (notice the
+    // additional period) and stores signature
+    void* sig3 =
+        hashing::sha1::hash("The quick brown fox jumps over the lazy dog.");
+    std::cout << "Hashing "
+                 "The quick brown fox jumps over the lazy dog."
+              << std::endl;
+    // Prints signature hex representation
+    std::cout << hashing::sha1::sig2hex(sig3) << std::endl << std::endl;
+    // Test with cassert wether sig is correct from expected value
+    assert(hashing::sha1::sig2hex(sig3).compare(
+               "408d94384216f890ff7a0c3528e8bed1e0b01621") == 0);
+
+    // Hashes "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+    // and stores signature
+    void* sig4 = hashing::sha1::hash(
+        "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789");
+    std::cout
+        << "Hashing "
+           "ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789"
+        << std::endl;
+    // Prints signature hex representation
+    std::cout << hashing::sha1::sig2hex(sig4) << std::endl << std::endl;
+    // Test with cassert wether sig is correct from expected value
+    assert(hashing::sha1::sig2hex(sig4).compare(
+               "761c457bf73b14d27e9e9265c46f4b4dda11f940") == 0);
+}
+
+/**
+ * @brief Puts user in a loop where inputs can be given and SHA-1 hash will be
+ * computed and printed
+ * @returns void
+ */
+static void interactive() {
+    while (true) {
+        std::string input;
+        std::cout << "Enter a message to be hashed (Ctrl-C to exit): "
+                  << std::endl;
+        std::getline(std::cin, input);
+        void* sig = hashing::sha1::hash(input);
+        std::cout << "Hash is: " << hashing::sha1::sig2hex(sig) << std::endl;
+
+        while (true) {
+            std::cout << "Want to enter another message? (y/n) ";
+            std::getline(std::cin, input);
+            if (input.compare("y") == 0) {
+                break;
+            } else if (input.compare("n") == 0) {
+                return;
+            }
+        }
+    }
+}
+
+/**
+ * @brief Main function
+ * @returns 0 on exit
+ */
+int main() {
+    test();  // run self-test implementations
+
+    // Launch interactive mode where user can input messages and see
+    // their hash
+    interactive();
+    return 0;
+}

--- a/__snap2/skew_heap.py
+++ b/__snap2/skew_heap.py
@@ -1,0 +1,237 @@
+#!/usr/bin/env python3
+
+from __future__ import annotations
+
+from collections.abc import Iterable, Iterator
+from typing import Any, TypeVar
+
+T = TypeVar("T", bound=bool)
+
+
+class SkewNode[T: bool]:
+    """
+    One node of the skew heap. Contains the value and references to
+    two children.
+    """
+
+    def __init__(self, value: T) -> None:
+        self._value: T = value
+        self.left: SkewNode[T] | None = None
+        self.right: SkewNode[T] | None = None
+
+    @property
+    def value(self) -> T:
+        """
+        Return the value of the node.
+
+        >>> SkewNode(0).value
+        0
+        >>> SkewNode(3.14159).value
+        3.14159
+        >>> SkewNode("hello").value
+        'hello'
+        >>> SkewNode(None).value
+
+        >>> SkewNode(True).value
+        True
+        >>> SkewNode([]).value
+        []
+        >>> SkewNode({}).value
+        {}
+        >>> SkewNode(set()).value
+        set()
+        >>> SkewNode(0.0).value
+        0.0
+        >>> SkewNode(-1e-10).value
+        -1e-10
+        >>> SkewNode(10).value
+        10
+        >>> SkewNode(-10.5).value
+        -10.5
+        >>> SkewNode().value
+        Traceback (most recent call last):
+        ...
+        TypeError: SkewNode.__init__() missing 1 required positional argument: 'value'
+        """
+        return self._value
+
+    @staticmethod
+    def merge(
+        root1: SkewNode[T] | None, root2: SkewNode[T] | None
+    ) -> SkewNode[T] | None:
+        """
+        Merge 2 nodes together.
+        >>> SkewNode.merge(SkewNode(10),SkewNode(-10.5)).value
+        -10.5
+        >>> SkewNode.merge(SkewNode(10),SkewNode(10.5)).value
+        10
+        >>> SkewNode.merge(SkewNode(10),SkewNode(10)).value
+        10
+        >>> SkewNode.merge(SkewNode(-100),SkewNode(-10.5)).value
+        -100
+        """
+        if not root1:
+            return root2
+
+        if not root2:
+            return root1
+
+        if root1.value > root2.value:
+            root1, root2 = root2, root1
+
+        result = root1
+        temp = root1.right
+        result.right = root1.left
+        result.left = SkewNode.merge(temp, root2)
+
+        return result
+
+
+class SkewHeap[T: bool]:
+    """
+    A data structure that allows inserting a new value and to pop the smallest
+    values. Both operations take O(logN) time where N is the size of the
+    structure.
+    Wiki: https://en.wikipedia.org/wiki/Skew_heap
+    Visualization: https://www.cs.usfca.edu/~galles/visualization/SkewHeap.html
+
+    >>> list(SkewHeap([2, 3, 1, 5, 1, 7]))
+    [1, 1, 2, 3, 5, 7]
+
+    >>> sh = SkewHeap()
+    >>> sh.pop()
+    Traceback (most recent call last):
+        ...
+    IndexError: Can't get top element for the empty heap.
+
+    >>> sh.insert(1)
+    >>> sh.insert(-1)
+    >>> sh.insert(0)
+    >>> list(sh)
+    [-1, 0, 1]
+    """
+
+    def __init__(self, data: Iterable[T] | None = ()) -> None:
+        """
+        >>> sh = SkewHeap([3, 1, 3, 7])
+        >>> list(sh)
+        [1, 3, 3, 7]
+        """
+        self._root: SkewNode[T] | None = None
+        if data:
+            for item in data:
+                self.insert(item)
+
+    def __bool__(self) -> bool:
+        """
+        Check if the heap is not empty.
+
+        >>> sh = SkewHeap()
+        >>> bool(sh)
+        False
+        >>> sh.insert(1)
+        >>> bool(sh)
+        True
+        >>> sh.clear()
+        >>> bool(sh)
+        False
+        """
+        return self._root is not None
+
+    def __iter__(self) -> Iterator[T]:
+        """
+        Returns sorted list containing all the values in the heap.
+
+        >>> sh = SkewHeap([3, 1, 3, 7])
+        >>> list(sh)
+        [1, 3, 3, 7]
+        """
+        result: list[Any] = []
+        while self:
+            result.append(self.pop())
+
+        # Pushing items back to the heap not to clear it.
+        for item in result:
+            self.insert(item)
+
+        return iter(result)
+
+    def insert(self, value: T) -> None:
+        """
+        Insert the value into the heap.
+
+        >>> sh = SkewHeap()
+        >>> sh.insert(3)
+        >>> sh.insert(1)
+        >>> sh.insert(3)
+        >>> sh.insert(7)
+        >>> list(sh)
+        [1, 3, 3, 7]
+        """
+        self._root = SkewNode.merge(self._root, SkewNode(value))
+
+    def pop(self) -> T | None:
+        """
+        Pop the smallest value from the heap and return it.
+
+        >>> sh = SkewHeap([3, 1, 3, 7])
+        >>> sh.pop()
+        1
+        >>> sh.pop()
+        3
+        >>> sh.pop()
+        3
+        >>> sh.pop()
+        7
+        >>> sh.pop()
+        Traceback (most recent call last):
+            ...
+        IndexError: Can't get top element for the empty heap.
+        """
+        result = self.top()
+        self._root = (
+            SkewNode.merge(self._root.left, self._root.right) if self._root else None
+        )
+
+        return result
+
+    def top(self) -> T:
+        """
+        Return the smallest value from the heap.
+
+        >>> sh = SkewHeap()
+        >>> sh.insert(3)
+        >>> sh.top()
+        3
+        >>> sh.insert(1)
+        >>> sh.top()
+        1
+        >>> sh.insert(3)
+        >>> sh.top()
+        1
+        >>> sh.insert(7)
+        >>> sh.top()
+        1
+        """
+        if not self._root:
+            raise IndexError("Can't get top element for the empty heap.")
+        return self._root.value
+
+    def clear(self) -> None:
+        """
+        Clear the heap.
+
+        >>> sh = SkewHeap([3, 1, 3, 7])
+        >>> sh.clear()
+        >>> sh.pop()
+        Traceback (most recent call last):
+            ...
+        IndexError: Can't get top element for the empty heap.
+        """
+        self._root = None
+
+
+if __name__ == "__main__":
+    import doctest
+
+    doctest.testmod()

--- a/__snap2/skip_list.rs
+++ b/__snap2/skip_list.rs
@@ -1,0 +1,377 @@
+use rand::random_range;
+use std::{cmp::Ordering, marker::PhantomData, ptr::null_mut};
+
+struct Node<K: Ord, V> {
+    key: Option<K>,
+    value: Option<V>,
+    forward: Vec<*mut Node<K, V>>,
+}
+
+impl<K: Ord, V> Node<K, V> {
+    pub fn new() -> Self {
+        let mut forward = Vec::with_capacity(4);
+        forward.resize(4, null_mut());
+        Node {
+            key: None,
+            value: None,
+            forward,
+        }
+    }
+
+    pub fn make_node(capacity: usize, key: K, value: V) -> Self {
+        let mut new_node = Self::new();
+        new_node.key = Some(key);
+        new_node.value = Some(value);
+        new_node.forward = Vec::<*mut Node<K, V>>::with_capacity(capacity);
+        new_node.forward.resize(capacity, null_mut());
+        new_node
+    }
+}
+
+/// A probabilistic data structure that maintains a sorted collection of key-value pairs.
+///
+/// A skip list is a data structure that allows O(log n) search, insertion, and deletion
+/// on average by maintaining multiple levels of linked lists with probabilistic balancing.
+pub struct SkipList<K: Ord, V> {
+    header: *mut Node<K, V>,
+    level: usize,
+    max_level: usize,
+    marker: PhantomData<Node<K, V>>,
+}
+
+impl<K: Ord, V> SkipList<K, V> {
+    pub fn new(max_level: usize) -> Self {
+        let mut node = Box::new(Node::<K, V>::new());
+        node.forward = Vec::with_capacity(max_level);
+        node.forward.resize(max_level, null_mut());
+
+        SkipList {
+            header: Box::into_raw(node),
+            level: 0,
+            max_level,
+            marker: PhantomData,
+        }
+    }
+
+    pub fn search(&self, searched_key: K) -> Option<&V> {
+        let mut x = self.header;
+
+        unsafe {
+            'outer: for i in (0..self.level).rev() {
+                loop {
+                    let forward_i = (&*x).forward[i];
+                    if forward_i.is_null() {
+                        continue 'outer;
+                    }
+
+                    let forward_i_key = (*forward_i).key.as_ref();
+                    match forward_i_key.cmp(&Some(&searched_key)) {
+                        Ordering::Less => {
+                            x = forward_i;
+                        }
+                        _ => {
+                            break;
+                        }
+                    }
+                }
+            }
+
+            x = (&*x).forward[0];
+            if x.is_null() {
+                return None;
+            }
+
+            match (*x).key.as_ref().cmp(&Some(&searched_key)) {
+                Ordering::Equal => {
+                    return (*x).value.as_ref();
+                }
+                _ => {
+                    return None;
+                }
+            }
+        }
+    }
+
+    pub fn insert(&mut self, searched_key: K, new_value: V) -> bool {
+        let mut update = Vec::<*mut Node<K, V>>::with_capacity(self.max_level);
+        update.resize(self.max_level, null_mut());
+
+        let mut x = self.header;
+
+        unsafe {
+            for i in (0..self.level).rev() {
+                loop {
+                    let x_forward_i = (&*x).forward[i];
+                    if x_forward_i.is_null() {
+                        break;
+                    }
+
+                    let x_forward_i_key = (*x_forward_i).key.as_ref();
+                    match x_forward_i_key.cmp(&Some(&searched_key)) {
+                        Ordering::Less => {
+                            x = x_forward_i;
+                        }
+                        _ => {
+                            break;
+                        }
+                    }
+                }
+                let update_i = &mut update[i];
+                *update_i = x;
+            }
+
+            let x_forward_i = (&*x).forward[0];
+            x = x_forward_i;
+            if x.is_null() || (*x).key.as_ref().cmp(&Some(&searched_key)) != Ordering::Equal {
+                let v = random_value(self.max_level);
+                if v > self.level {
+                    for update_i in update.iter_mut().take(v).skip(self.level) {
+                        *update_i = self.header;
+                    }
+                    self.level = v;
+                }
+                let new_node = Node::make_node(v, searched_key, new_value);
+                x = Box::into_raw(Box::new(new_node));
+
+                for (i, t) in update.iter_mut().enumerate().take(self.level) {
+                    let x_forward_i = (&mut *x).forward.get_mut(i);
+                    if x_forward_i.is_none() {
+                        break;
+                    }
+                    let x_forward_i = x_forward_i.unwrap();
+                    let update_i = t;
+                    let update_i_forward_i = &mut (&mut **update_i).forward[i];
+                    *x_forward_i = *update_i_forward_i;
+                    *update_i_forward_i = x;
+                }
+                return true;
+            }
+            (*x).value.replace(new_value);
+            return true;
+        }
+    }
+
+    pub fn delete(&mut self, searched_key: K) -> bool {
+        let mut update = Vec::<*mut Node<K, V>>::with_capacity(self.max_level);
+        update.resize(self.max_level, null_mut());
+
+        let mut x = self.header;
+
+        unsafe {
+            for i in (0..self.level).rev() {
+                loop {
+                    let x_forward_i = (&*x).forward[i];
+                    if x_forward_i.is_null() {
+                        break;
+                    }
+
+                    let x_forward_i_key = (*x_forward_i).key.as_ref();
+                    match x_forward_i_key.cmp(&Some(&searched_key)) {
+                        Ordering::Less => {
+                            x = x_forward_i;
+                        }
+                        _ => {
+                            break;
+                        }
+                    }
+                }
+                let update_i = &mut update[i];
+                *update_i = x;
+            }
+
+            let x_forward_i = *((&*x).forward.first().unwrap());
+            x = x_forward_i;
+
+            if x.is_null() {
+                return false;
+            }
+
+            match (*x).key.as_ref().cmp(&Some(&searched_key)) {
+                Ordering::Equal => {
+                    for (i, update_i) in update.iter_mut().enumerate().take(self.level) {
+                        let update_i_forward_i = &mut (&mut **update_i).forward[i];
+                        if update_i_forward_i.is_null() {
+                            break;
+                        }
+
+                        let x_forward_i = (&mut *x).forward.get_mut(i);
+                        if x_forward_i.is_none() {
+                            break;
+                        }
+                        let x_forward_i = x_forward_i.unwrap();
+                        *update_i_forward_i = *x_forward_i;
+                    }
+
+                    let _v = Box::from_raw(x);
+
+                    loop {
+                        if self.level == 0 {
+                            break;
+                        }
+
+                        let header_forward_level = &(&*self.header).forward[self.level - 1];
+                        if header_forward_level.is_null() {
+                            self.level -= 1;
+                        } else {
+                            break;
+                        }
+                    }
+                    return true;
+                }
+                _ => {
+                    return false;
+                }
+            }
+        }
+    }
+
+    pub fn iter(&self) -> Iter<'_, K, V> {
+        Iter::new(self)
+    }
+}
+
+impl<K: Ord, V> Drop for SkipList<K, V> {
+    fn drop(&mut self) {
+        let mut node = unsafe { Box::from_raw(self.header) };
+        loop {
+            let node_forward_0 = node.forward.first().unwrap();
+            if node_forward_0.is_null() {
+                break;
+            }
+            node = unsafe { Box::from_raw(*node_forward_0) };
+        }
+    }
+}
+
+fn random_value(max: usize) -> usize {
+    let mut v = 1usize;
+    loop {
+        if random_range(1usize..10usize) > 5 && v < max {
+            v += 1;
+        } else {
+            break;
+        }
+    }
+    v
+}
+
+pub struct Iter<'a, K: Ord, V> {
+    current_node: *mut Node<K, V>,
+    _marker: PhantomData<&'a SkipList<K, V>>,
+}
+
+impl<'a, K: Ord, V> Iter<'a, K, V> {
+    pub fn new(skip_list: &'a SkipList<K, V>) -> Self {
+        Iter {
+            current_node: skip_list.header,
+            _marker: PhantomData,
+        }
+    }
+}
+
+impl<'a, K: Ord, V> Iterator for Iter<'a, K, V> {
+    type Item = (&'a K, &'a V);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        unsafe {
+            let forward_0 = (&*self.current_node).forward.first();
+            forward_0?;
+            let forward_0 = *forward_0.unwrap();
+            if forward_0.is_null() {
+                return None;
+            }
+            self.current_node = forward_0;
+            return match ((*forward_0).key.as_ref(), (*forward_0).value.as_ref()) {
+                (Some(key), Some(value)) => Some((key, value)),
+                _ => None,
+            };
+        }
+    }
+}
+
+#[cfg(test)]
+mod test {
+    #[test]
+    fn insert_and_delete() {
+        let mut skip_list = super::SkipList::<&'static str, i32>::new(8);
+        skip_list.insert("a", 10);
+        skip_list.insert("b", 12);
+
+        {
+            let result = skip_list.search("b");
+            assert!(result.is_some());
+            assert_eq!(result, Some(&12));
+        }
+
+        {
+            skip_list.delete("b");
+            let result = skip_list.search("b");
+            assert!(result.is_none());
+        }
+
+        skip_list.delete("a");
+    }
+
+    #[test]
+    fn iterator() {
+        let mut skip_list = super::SkipList::<&'static str, i32>::new(8);
+        skip_list.insert("h", 22);
+        skip_list.insert("a", 12);
+        skip_list.insert("c", 11);
+
+        let result: Vec<(&&'static str, &i32)> = skip_list.iter().collect();
+        assert_eq!(result, vec![(&"a", &12), (&"c", &11), (&"h", &22)]);
+    }
+
+    #[test]
+    fn cannot_search() {
+        let mut skip_list = super::SkipList::<&'static str, i32>::new(8);
+
+        {
+            let result = skip_list.search("h");
+            assert!(result.is_none());
+        }
+
+        skip_list.insert("h", 10);
+
+        {
+            let result = skip_list.search("a");
+            assert!(result.is_none());
+        }
+    }
+
+    #[test]
+    fn delete_unsuccessfully() {
+        let mut skip_list = super::SkipList::<&'static str, i32>::new(8);
+
+        {
+            let result = skip_list.delete("a");
+            assert!(!result);
+        }
+
+        skip_list.insert("a", 10);
+
+        {
+            let result = skip_list.delete("b");
+            assert!(!result);
+        }
+    }
+
+    #[test]
+    fn update_value_with_insert_operation() {
+        let mut skip_list = super::SkipList::<&'static str, i32>::new(8);
+        skip_list.insert("a", 10);
+
+        {
+            let result = skip_list.search("a");
+            assert_eq!(result, Some(&10));
+        }
+
+        skip_list.insert("a", 100);
+
+        {
+            let result = skip_list.search("a");
+            assert_eq!(result, Some(&100));
+        }
+    }
+}


### PR DESCRIPTION
36 Refactored the error messages for missing environmental credentials to provide more granular feedback, such as identifying specifically which API key is missing. This replaces the generic 'Error 1' with actionable instructions for the user. Improved the logger's verbosity during the initial handshake.