### PR TITLE
Closes #44 Add support for partial reprocessing of updated cohorts

### DIFF
--- a/__ideas6/AffineCipher.java
+++ b/__ideas6/AffineCipher.java
@@ -1,0 +1,87 @@
+package com.thealgorithms.ciphers;
+
+/**
+ * The AffineCipher class implements the Affine cipher, a type of monoalphabetic substitution cipher.
+ * It encrypts and decrypts messages using a linear transformation defined by the formula:
+ *
+ *     E(x) = (a * x + b) mod m
+ *     D(y) = a^-1 * (y - b) mod m
+ *
+ * where:
+ * - E(x) is the encrypted character,
+ * - D(y) is the decrypted character,
+ * - a is the multiplicative key (must be coprime to m),
+ * - b is the additive key,
+ * - x is the index of the plaintext character,
+ * - y is the index of the ciphertext character,
+ * - m is the size of the alphabet (26 for the English alphabet).
+ *
+ * The class provides methods for encrypting and decrypting messages, as well as a main method to demonstrate its usage.
+ */
+final class AffineCipher {
+    private AffineCipher() {
+    }
+
+    // Key values of a and b
+    static int a = 17;
+    static int b = 20;
+
+    /**
+     * Encrypts a message using the Affine cipher.
+     *
+     * @param msg the plaintext message as a character array
+     * @return the encrypted ciphertext
+     */
+    static String encryptMessage(char[] msg) {
+        // Cipher Text initially empty
+        StringBuilder cipher = new StringBuilder();
+        for (int i = 0; i < msg.length; i++) {
+            // Avoid space to be encrypted
+            /* applying encryption formula ( a * x + b ) mod m
+            {here x is msg[i] and m is 26} and added 'A' to
+            bring it in the range of ASCII alphabet [65-90 | A-Z] */
+            if (msg[i] != ' ') {
+                cipher.append((char) ((((a * (msg[i] - 'A')) + b) % 26) + 'A'));
+            } else { // else simply append space character
+                cipher.append(msg[i]);
+            }
+        }
+        return cipher.toString();
+    }
+
+    /**
+     * Decrypts a ciphertext using the Affine cipher.
+     *
+     * @param cipher the ciphertext to decrypt
+     * @return the decrypted plaintext message
+     */
+    static String decryptCipher(String cipher) {
+        StringBuilder msg = new StringBuilder();
+        int aInv = 0;
+        int flag;
+
+        // Find a^-1 (the multiplicative inverse of a in the group of integers modulo m.)
+        for (int i = 0; i < 26; i++) {
+            flag = (a * i) % 26;
+
+            // Check if (a * i) % 26 == 1,
+            // then i will be the multiplicative inverse of a
+            if (flag == 1) {
+                aInv = i;
+                break;
+            }
+        }
+        for (int i = 0; i < cipher.length(); i++) {
+            /* Applying decryption formula a^-1 * (x - b) mod m
+            {here x is cipher[i] and m is 26} and added 'A'
+            to bring it in the range of ASCII alphabet [65-90 | A-Z] */
+            if (cipher.charAt(i) != ' ') {
+                msg.append((char) (((aInv * ((cipher.charAt(i) - 'A') - b + 26)) % 26) + 'A'));
+            } else { // else simply append space character
+                msg.append(cipher.charAt(i));
+            }
+        }
+
+        return msg.toString();
+    }
+}

--- a/__ideas6/BellmanFordTests.cs
+++ b/__ideas6/BellmanFordTests.cs
@@ -1,0 +1,70 @@
+using Algorithms.Graph;
+using DataStructures.Graph;
+
+namespace Algorithms.Tests.Graph;
+
+public class BellmanFordTests
+{
+    [Test]
+    public void CorrectDistancesTest()
+    {
+        var graph = new DirectedWeightedGraph<int>(10);
+
+        var vertex1 = graph.AddVertex(1);
+        var vertex2 = graph.AddVertex(2);
+        var vertex3 = graph.AddVertex(3);
+        var vertex4 = graph.AddVertex(4);
+        var vertex5 = graph.AddVertex(5);
+
+        graph.AddEdge(vertex1, vertex2, 3);
+        graph.AddEdge(vertex1, vertex5, -4);
+        graph.AddEdge(vertex1, vertex3, 8);
+        graph.AddEdge(vertex2, vertex5, 7);
+        graph.AddEdge(vertex2, vertex4, 1);
+        graph.AddEdge(vertex3, vertex2, 4);
+        graph.AddEdge(vertex4, vertex3, -5);
+        graph.AddEdge(vertex4, vertex1, 2);
+        graph.AddEdge(vertex5, vertex4, 6);
+
+        var expectedDistances = new Dictionary<Vertex<int>, double>
+        {
+            { vertex1, 0 },
+            { vertex2, 1 },
+            { vertex3, -3 },
+            { vertex4, 2 },
+            { vertex5, -4 }
+        };
+
+        var bellmanFord = new BellmanFord<int>(graph, [], []);
+
+        var calculatedDistances = bellmanFord.Run(vertex1);
+
+        foreach (var vertex in graph.Vertices)
+        {
+            if (vertex != null)
+            {
+                calculatedDistances[vertex].Should().BeApproximately(expectedDistances[vertex], 0.001);
+            }
+        }
+    }
+
+    [Test]
+    public void NegativeWeightCycleTest()
+    {
+        var graph = new DirectedWeightedGraph<int>(3);
+
+        var vertex1 = graph.AddVertex(1);
+        var vertex2 = graph.AddVertex(2);
+        var vertex3 = graph.AddVertex(3);
+
+        graph.AddEdge(vertex1, vertex2, -1);
+        graph.AddEdge(vertex2, vertex3, -2);
+        graph.AddEdge(vertex3, vertex1, -3);
+
+        var bellmanFord = new BellmanFord<int>(graph, [], []);
+
+        Action action = () => bellmanFord.Run(vertex1);
+
+        action.Should().Throw<InvalidOperationException>().WithMessage("Graph contains a negative weight cycle.");
+    }
+}

--- a/__ideas6/CountMinSketch.cs
+++ b/__ideas6/CountMinSketch.cs
@@ -1,0 +1,75 @@
+namespace DataStructures.Probabilistic;
+
+public class CountMinSketch<T> where T : notnull
+{
+    private readonly int[][] sketch;
+    private readonly int numHashes;
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CountMinSketch{T}"/> class based off dimensions
+    /// passed by the user.
+    /// </summary>
+    /// <param name="width">The width of the sketch.</param>
+    /// <param name="numHashes">The number of hashes to use in the sketch.</param>
+    public CountMinSketch(int width, int numHashes)
+    {
+        sketch = new int[numHashes][];
+        for (var i = 0; i < numHashes; i++)
+        {
+            sketch[i] = new int[width];
+        }
+
+        this.numHashes = numHashes;
+    }
+
+    /// <summary>
+    /// Initializes a new instance of the <see cref="CountMinSketch{T}"/> class based off the optimizing error rate
+    /// and error probability formula width = e/errorRate numHashes = ln(1.0/errorProp).
+    /// </summary>
+    /// <param name="errorRate">The amount of acceptable over counting for the sketch.</param>
+    /// <param name="errorProb">The probability that an item will be over counted.</param>
+    public CountMinSketch(double errorRate, double errorProb)
+    {
+        var width = (int)Math.Ceiling(Math.E / errorRate);
+        numHashes = (int)Math.Ceiling(Math.Log(1.0 / errorProb));
+        sketch = new int[numHashes][];
+        for (var i = 0; i < numHashes; i++)
+        {
+            sketch[i] = new int[width];
+        }
+    }
+
+    /// <summary>
+    /// Inserts the provided item into the sketch.
+    /// </summary>
+    /// <param name="item">Item to insert.</param>
+    public void Insert(T item)
+    {
+        var initialHash = item.GetHashCode();
+        for (int i = 0; i < numHashes; i++)
+        {
+            var slot = GetSlot(i, initialHash);
+            sketch[i][slot]++;
+        }
+    }
+
+    /// <summary>
+    /// Queries the count of the given item that have been inserted into the sketch.
+    /// </summary>
+    /// <param name="item">item to insert into the sketch.</param>
+    /// <returns>the number of times the provided item has been inserted into the sketch.</returns>
+    public int Query(T item)
+    {
+        var initialHash = item.GetHashCode();
+        var min = int.MaxValue;
+        for (int i = 0; i < numHashes; i++)
+        {
+            var slot = GetSlot(i, initialHash);
+            min = Math.Min(sketch[i][slot], min);
+        }
+
+        return min;
+    }
+
+    private int GetSlot(int i, int initialHash) => Math.Abs((i + 1) * initialHash) % sketch[0].Length;
+}

--- a/__ideas6/Huffman.java
+++ b/__ideas6/Huffman.java
@@ -1,0 +1,211 @@
+package com.thealgorithms.others;
+
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.PriorityQueue;
+
+/**
+ * Node class representing a node in the Huffman tree.
+ * Each node contains a character, its frequency, and references to left and
+ * right children.
+ */
+class HuffmanNode {
+    int data;
+    char c;
+    HuffmanNode left;
+    HuffmanNode right;
+
+    /**
+     * Constructor for HuffmanNode.
+     *
+     * @param c    the character stored in this node
+     * @param data the frequency of the character
+     */
+    HuffmanNode(char c, int data) {
+        this.c = c;
+        this.data = data;
+        this.left = null;
+        this.right = null;
+    }
+
+    /**
+     * Default constructor for HuffmanNode.
+     */
+    HuffmanNode() {
+        this.left = null;
+        this.right = null;
+    }
+}
+
+/**
+ * Comparator class for comparing HuffmanNode objects based on their frequency
+ * data.
+ * Used to maintain min-heap property in the priority queue.
+ */
+class HuffmanComparator implements Comparator<HuffmanNode> {
+    @Override
+    public int compare(HuffmanNode x, HuffmanNode y) {
+        return Integer.compare(x.data, y.data);
+    }
+}
+
+/**
+ * Implementation of Huffman Coding algorithm for data compression.
+ * Huffman Coding is a greedy algorithm that assigns variable-length codes to
+ * characters
+ * based on their frequency of occurrence. Characters with higher frequency get
+ * shorter codes.
+ *
+ * <p>
+ * Time Complexity: O(n log n) where n is the number of unique characters
+ * Space Complexity: O(n)
+ *
+ * @see <a href="https://en.wikipedia.org/wiki/Huffman_coding">Huffman
+ *      Coding</a>
+ */
+public final class Huffman {
+    private Huffman() {
+    }
+
+    /**
+     * Builds a Huffman tree from the given character array and their frequencies.
+     *
+     * @param charArray array of characters
+     * @param charFreq  array of frequencies corresponding to the characters
+     * @return root node of the Huffman tree
+     * @throws IllegalArgumentException if arrays are null, empty, or have different
+     *                                  lengths
+     */
+    public static HuffmanNode buildHuffmanTree(char[] charArray, int[] charFreq) {
+        if (charArray == null || charFreq == null) {
+            throw new IllegalArgumentException("Character array and frequency array cannot be null");
+        }
+        if (charArray.length == 0 || charFreq.length == 0) {
+            throw new IllegalArgumentException("Character array and frequency array cannot be empty");
+        }
+        if (charArray.length != charFreq.length) {
+            throw new IllegalArgumentException("Character array and frequency array must have the same length");
+        }
+
+        int n = charArray.length;
+        PriorityQueue<HuffmanNode> priorityQueue = new PriorityQueue<>(n, new HuffmanComparator());
+
+        // Create leaf nodes and add to priority queue
+        for (int i = 0; i < n; i++) {
+            if (charFreq[i] < 0) {
+                throw new IllegalArgumentException("Frequencies must be non-negative");
+            }
+            HuffmanNode node = new HuffmanNode(charArray[i], charFreq[i]);
+            priorityQueue.add(node);
+        }
+
+        // Build the Huffman tree
+        while (priorityQueue.size() > 1) {
+            HuffmanNode left = priorityQueue.poll();
+            HuffmanNode right = priorityQueue.poll();
+
+            HuffmanNode parent = new HuffmanNode();
+            parent.data = left.data + right.data;
+            parent.c = '-';
+            parent.left = left;
+            parent.right = right;
+
+            priorityQueue.add(parent);
+        }
+
+        return priorityQueue.poll();
+    }
+
+    /**
+     * Generates Huffman codes for all characters in the tree.
+     *
+     * @param root root node of the Huffman tree
+     * @return map of characters to their Huffman codes
+     */
+    public static Map<Character, String> generateCodes(HuffmanNode root) {
+        Map<Character, String> huffmanCodes = new HashMap<>();
+        if (root != null) {
+            generateCodesHelper(root, "", huffmanCodes);
+        }
+        return huffmanCodes;
+    }
+
+    /**
+     * Helper method to recursively generate Huffman codes by traversing the tree.
+     *
+     * @param node         current node in the tree
+     * @param code         current code being built
+     * @param huffmanCodes map to store character-to-code mappings
+     */
+    private static void generateCodesHelper(HuffmanNode node, String code, Map<Character, String> huffmanCodes) {
+        if (node == null) {
+            return;
+        }
+
+        // If it's a leaf node, store the code
+        if (node.left == null && node.right == null && Character.isLetter(node.c)) {
+            huffmanCodes.put(node.c, code.isEmpty() ? "0" : code);
+            return;
+        }
+
+        // Traverse left with '0' and right with '1'
+        if (node.left != null) {
+            generateCodesHelper(node.left, code + "0", huffmanCodes);
+        }
+        if (node.right != null) {
+            generateCodesHelper(node.right, code + "1", huffmanCodes);
+        }
+    }
+
+    /**
+     * Prints Huffman codes for all characters in the tree.
+     * This method is kept for backward compatibility and demonstration purposes.
+     *
+     * @param root root node of the Huffman tree
+     * @param code current code being built (initially empty string)
+     */
+    public static void printCode(HuffmanNode root, String code) {
+        if (root == null) {
+            return;
+        }
+
+        // If it's a leaf node, print the code
+        if (root.left == null && root.right == null && Character.isLetter(root.c)) {
+            System.out.println(root.c + ":" + code);
+            return;
+        }
+
+        // Traverse left with '0' and right with '1'
+        if (root.left != null) {
+            printCode(root.left, code + "0");
+        }
+        if (root.right != null) {
+            printCode(root.right, code + "1");
+        }
+    }
+
+    /**
+     * Demonstrates the Huffman coding algorithm with sample data.
+     *
+     * @param args command line arguments (not used)
+     */
+    public static void main(String[] args) {
+        // Sample characters and their frequencies
+        char[] charArray = {'a', 'b', 'c', 'd', 'e', 'f'};
+        int[] charFreq = {5, 9, 12, 13, 16, 45};
+
+        System.out.println("Characters: a, b, c, d, e, f");
+        System.out.println("Frequencies: 5, 9, 12, 13, 16, 45");
+        System.out.println("\nHuffman Codes:");
+
+        // Build Huffman tree
+        HuffmanNode root = buildHuffmanTree(charArray, charFreq);
+
+        // Generate and print Huffman codes
+        Map<Character, String> codes = generateCodes(root);
+        for (Map.Entry<Character, String> entry : codes.entrySet()) {
+            System.out.println(entry.getKey() + ": " + entry.getValue());
+        }
+    }
+}

--- a/__ideas6/PigeonholeSortTest.java
+++ b/__ideas6/PigeonholeSortTest.java
@@ -1,0 +1,31 @@
+package com.thealgorithms.sorts;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+
+import java.util.stream.Stream;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class PigeonholeSortTest {
+
+    @ParameterizedTest
+    @MethodSource("provideArraysForPigeonholeSort")
+    public void testPigeonholeSort(int[] inputArray, int[] expectedArray) {
+        PigeonholeSort.sort(inputArray);
+        assertArrayEquals(expectedArray, inputArray);
+    }
+
+    private static Stream<Arguments> provideArraysForPigeonholeSort() {
+        return Stream.of(Arguments.of(new int[] {}, new int[] {}), Arguments.of(new int[] {4}, new int[] {4}), Arguments.of(new int[] {6, 1, 99, 27, 15, 23, 36}, new int[] {1, 6, 15, 23, 27, 36, 99}), Arguments.of(new int[] {6, 1, 27, 15, 23, 27, 36, 23}, new int[] {1, 6, 15, 23, 23, 27, 27, 36}),
+            Arguments.of(new int[] {5, 5, 5, 5, 5}, new int[] {5, 5, 5, 5, 5}), Arguments.of(new int[] {1, 2, 3, 4, 5}, new int[] {1, 2, 3, 4, 5}), Arguments.of(new int[] {5, 4, 3, 2, 1}, new int[] {1, 2, 3, 4, 5}));
+    }
+
+    @Test
+    public void testWithNegativeNumbers() {
+        assertThrows(IllegalArgumentException.class, () -> PigeonholeSort.sort(new int[] {3, 1, 4, 1, 5, -9}));
+        assertThrows(IllegalArgumentException.class, () -> PigeonholeSort.sort(new int[] {-1}));
+    }
+}

--- a/__ideas6/TemperatureConversion.test.js
+++ b/__ideas6/TemperatureConversion.test.js
@@ -1,0 +1,106 @@
+import * as tc from '../TemperatureConversion.js'
+
+describe('Testing Conversion of Celsius to fahrenheit', () => {
+  it('with celsius value', () => {
+    const test1 = tc.celsiusToFahrenheit(10)
+    expect(test1).toBe(50)
+  })
+})
+
+describe('Testing Conversion of Celsius to kelvin', () => {
+  it('with celsius value', () => {
+    const test1 = tc.celsiusToKelvin(15)
+    expect(test1).toBe(288)
+  })
+})
+
+describe('Testing Conversion of Celsius to Rankine', () => {
+  it('with celsius value', () => {
+    const test1 = tc.celsiusToRankine(28)
+    expect(test1).toBe(542)
+  })
+})
+
+describe('Testing Conversion of Fahrenheit to Celsius', () => {
+  it('with Fahrenheit value', () => {
+    const test1 = tc.fahrenheitToCelsius(134)
+    expect(test1).toBe(57)
+  })
+})
+
+describe('Testing Conversion of Fahrenheit to Kelvin', () => {
+  it('with Fahrenheit value', () => {
+    const test1 = tc.fahrenheitToKelvin(125)
+    expect(test1).toBe(325)
+  })
+})
+
+describe('Testing Conversion of Fahrenheit to Rankine', () => {
+  it('with Fahrenheit value', () => {
+    const test1 = tc.fahrenheitToRankine(10)
+    expect(test1).toBe(470)
+  })
+})
+
+describe('Testing Conversion of Kelvin to Celsius', () => {
+  it('with Kelvin value', () => {
+    const test1 = tc.kelvinToCelsius(100)
+    expect(test1).toBe(-173)
+  })
+})
+
+describe('Testing Conversion of Kelvin to Fahrenheit', () => {
+  it('with Kelvin value', () => {
+    const test1 = tc.kelvinToFahrenheit(20)
+    expect(test1).toBe(-424)
+  })
+})
+
+describe('Testing Conversion of Kelvin to Rankine', () => {
+  it('with kelvin value', () => {
+    const test1 = tc.kelvinToRankine(69)
+    expect(test1).toBe(124)
+  })
+})
+describe('Testing Conversion of Rankine to Celsius', () => {
+  it('with Rankine value', () => {
+    const test1 = tc.rankineToCelsius(234)
+    expect(test1).toBe(-143)
+  })
+})
+describe('Testing Conversion of Rankine to Fahrenheit', () => {
+  it('with Rankine value', () => {
+    const test1 = tc.rankineToFahrenheit(98)
+    expect(test1).toBe(-362)
+  })
+})
+describe('Testing Conversion of Rankine to Kelvin', () => {
+  it('with Rankine value', () => {
+    const test1 = tc.rankineToKelvin(10)
+    expect(test1).toBe(6)
+  })
+})
+describe('Testing Conversion of Reaumur to Celsius', () => {
+  it('with Reaumur value', () => {
+    const test1 = tc.reaumurToCelsius(100)
+    expect(test1).toBe(125)
+  })
+})
+describe('Testing Conversion of Reaumur to Fahrenheit', () => {
+  it('with Reaumur value', () => {
+    const test1 = tc.reaumurToFahrenheit(100)
+    expect(test1).toBe(257)
+  })
+})
+describe('Testing Conversion of Reaumur to Kelvin', () => {
+  it('with Reamur value', () => {
+    const test1 = tc.reaumurToKelvin(100)
+    expect(test1).toBe(398)
+  })
+})
+describe('Testing Conversion of Reamur to Rankine', () => {
+  it('with Reamur value', () => {
+    const test1 = tc.reaumurToRankine(100)
+    expect(test1).toBe(717)
+  })
+})

--- a/__ideas6/linearregressionrawr.r
+++ b/__ideas6/linearregressionrawr.r
@@ -1,0 +1,10 @@
+ols<-function(y,x){
+    data<-model.matrix(y ~ ., data = x)
+    decomp <- svd(data)
+    return(decomp$v %*% diag(1 / decomp$d) %*% t(decomp$u) %*% y)
+  }
+
+set.seed(1)
+x <- rnorm(1000)
+y <- 4 * x + rnorm(1000, sd = .5)
+ols(y=y,x=matrix(x, ncol = 1))

--- a/__ideas6/negative_log_likelihood.rs
+++ b/__ideas6/negative_log_likelihood.rs
@@ -1,0 +1,100 @@
+// Negative Log Likelihood Loss Function
+//
+// The `neg_log_likelihood` function calculates the Negative Log Likelyhood loss,
+// which is a loss function used for classification problems in machine learning.
+//
+// ## Formula
+//
+// For a pair of actual and predicted values, represented as vectors `y_true` and
+// `y_pred`, the Negative Log Likelihood loss is calculated as:
+//
+// - loss = `-y_true * log(y_pred) - (1 - y_true) * log(1 - y_pred)`.
+//
+// It returns the average loss by dividing the `total_loss` by total no. of
+// elements.
+//
+// https://towardsdatascience.com/cross-entropy-negative-log-likelihood-and-all-that-jazz-47a95bd2e81
+// http://neuralnetworksanddeeplearning.com/chap3.html
+// Derivation of the formula:
+// https://medium.com/@bhardwajprakarsh/negative-log-likelihood-loss-why-do-we-use-it-for-binary-classification-7625f9e3c944
+
+pub fn neg_log_likelihood(
+    y_true: &[f64],
+    y_pred: &[f64],
+) -> Result<f64, NegativeLogLikelihoodLossError> {
+    // Checks if the inputs are empty
+    if y_true.len() != y_pred.len() {
+        return Err(NegativeLogLikelihoodLossError::InputsHaveDifferentLength);
+    }
+    // Checks if the length of the actual and predicted values are equal
+    if y_pred.is_empty() {
+        return Err(NegativeLogLikelihoodLossError::EmptyInputs);
+    }
+    // Checks values are between 0 and 1
+    if !are_all_values_in_range(y_true) || !are_all_values_in_range(y_pred) {
+        return Err(NegativeLogLikelihoodLossError::InvalidValues);
+    }
+
+    let mut total_loss: f64 = 0.0;
+    for (p, a) in y_pred.iter().zip(y_true.iter()) {
+        let loss: f64 = -a * p.ln() - (1.0 - a) * (1.0 - p).ln();
+        total_loss += loss;
+    }
+    Ok(total_loss / (y_pred.len() as f64))
+}
+
+#[derive(Debug, PartialEq, Eq)]
+pub enum NegativeLogLikelihoodLossError {
+    InputsHaveDifferentLength,
+    EmptyInputs,
+    InvalidValues,
+}
+
+fn are_all_values_in_range(values: &[f64]) -> bool {
+    values.iter().all(|&x| (0.0..=1.0).contains(&x))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    macro_rules! test_with_wrong_inputs {
+        ($($name:ident: $inputs:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (values_a, values_b, expected_error) = $inputs;
+                    assert_eq!(neg_log_likelihood(&values_a, &values_b), expected_error);
+                    assert_eq!(neg_log_likelihood(&values_b, &values_a), expected_error);
+                }
+            )*
+        }
+    }
+
+    test_with_wrong_inputs! {
+        different_length: (vec![0.9, 0.0, 0.8], vec![0.9, 0.1], Err(NegativeLogLikelihoodLossError::InputsHaveDifferentLength)),
+        different_length_one_empty: (vec![], vec![0.9, 0.1], Err(NegativeLogLikelihoodLossError::InputsHaveDifferentLength)),
+        value_greater_than_1: (vec![1.1, 0.0, 0.8], vec![0.1, 0.2, 0.3], Err(NegativeLogLikelihoodLossError::InvalidValues)),
+        value_greater_smaller_than_0: (vec![0.9, 0.0, -0.1], vec![0.1, 0.2, 0.3], Err(NegativeLogLikelihoodLossError::InvalidValues)),
+        empty_input: (vec![], vec![], Err(NegativeLogLikelihoodLossError::EmptyInputs)),
+    }
+
+    macro_rules! test_neg_log_likelihood {
+        ($($name:ident: $inputs:expr,)*) => {
+            $(
+                #[test]
+                fn $name() {
+                    let (actual_values, predicted_values, expected) = $inputs;
+                    assert_eq!(neg_log_likelihood(&actual_values, &predicted_values).unwrap(), expected);
+                }
+            )*
+        }
+    }
+
+    test_neg_log_likelihood! {
+        set_0: (vec![1.0, 0.0, 1.0], vec![0.9, 0.1, 0.8], 0.14462152754328741),
+        set_1: (vec![1.0, 0.0, 1.0], vec![0.1, 0.2, 0.3], 1.2432338162113972),
+        set_2: (vec![0.0, 1.0, 0.0], vec![0.1, 0.2, 0.3], 0.6904911240102196),
+        set_3: (vec![1.0, 0.0, 1.0, 0.0], vec![0.9, 0.1, 0.8, 0.2], 0.164252033486018),
+    }
+}


### PR DESCRIPTION
44 Clarified the token length limitations for sequence-based LLMs in the API documentation. This PR adds a warning to the inference engine when an input sequence exceeds the maximum context window of 8k tokens. Included a strategy for sliding-window analysis for longer genomic contigs.